### PR TITLE
Updated dropdown menu for 2017-07.html

### DIFF
--- a/agenda-2017-07.html
+++ b/agenda-2017-07.html
@@ -189,6 +189,7 @@ $(document).ready(function () {
   </a>
   <ul class="dropdown-menu" role="menu">
     <li>
+      <a href="agenda-2018-08.html">August 2018</a>
       <a href="agenda-2017-07.html">July 2017</a>
     </li>
   </ul>


### PR DESCRIPTION
added the 2018 page to the dropdown navigation.

Question: 
Is there a better way to do have this dropdown menu auto-generate, depending on the .html pages in the repo? 

I feel like this could be hard to remember to do down the line as there are more and more trainings